### PR TITLE
[FIX]: Update Content-Type header to include charset in Slack SDK request

### DIFF
--- a/pkg/slack/utils.go
+++ b/pkg/slack/utils.go
@@ -20,7 +20,7 @@ func (s *SlackSDK) sendRequest(endpoint, method string, payload interface{}) (ma
 	}
 
 	req.Header.Set("Authorization", "Bearer "+s.Token)
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
This pull request includes a small but important change to the `sendRequest` function in the `pkg/slack/utils.go` file. The change ensures that the `Content-Type` header specifies the character encoding as UTF-8.

* [`pkg/slack/utils.go`](diffhunk://#diff-a4f4dd95c4cdc6fc16b4a7a3d99618bef0a33985b7693b5cf27dcfcc07269085L23-R23): Updated the `Content-Type` header to include `charset=utf-8` in the `sendRequest` function.